### PR TITLE
feat: proposal guardian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cache
 artifacts
 yarn-error.log
 .DS_Store
+yarn.lock

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,10 @@ node_modules
 artifacts
 cache
 coverage*
-contracts*
+contracts/test*
+contracts/SafeMath.sol
+contracts/Timelock.sol
+contracts/Comp.sol
+contracts/GovernorBravoDelegator.sol
+contracts/GovernorBravoInterfaces.sol
 typechain-types

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+    "plugins": ["prettier-plugin-solidity"],
+    "overrides": [
+      {
+        "files": "*.sol",
+        "options": {
+          "bracketSpacing": true
+        }
+      }
+    ]
+  }

--- a/contracts/GovernorBravoDelegate.sol
+++ b/contracts/GovernorBravoDelegate.sol
@@ -381,14 +381,12 @@ contract GovernorBravoDelegate is
 
         // Proposer can cancel
         if (msg.sender != proposal.proposer) {
-            // Whitelisted proposers can't be canceled for falling below proposal threshold
-            if (isWhitelisted(proposal.proposer)) {
+            if (msg.sender != whitelistGuardian) {
+                // Whitelisted proposers can't be canceled for falling below proposal threshold
                 require(
-                    (comp.getPriorVotes(proposal.proposer, block.number - 1) <
-                        proposalThreshold) && msg.sender == whitelistGuardian,
+                    !isWhitelisted(proposal.proposer),
                     "GovernorBravo::cancel: whitelisted proposer"
                 );
-            } else {
                 require(
                     (comp.getPriorVotes(proposal.proposer, block.number - 1) <
                         proposalThreshold),
@@ -653,7 +651,7 @@ contract GovernorBravoDelegate is
 
     /**
      * @notice View function which returns if an account is whitelisted
-     * @param account Account to check white list status of
+     * @param account Account to check whitelist status of
      * @return If the account is whitelisted
      */
     function isWhitelisted(address account) public view returns (bool) {

--- a/contracts/GovernorBravoDelegate.sol
+++ b/contracts/GovernorBravoDelegate.sol
@@ -368,7 +368,7 @@ contract GovernorBravoDelegate is
     }
 
     /**
-     * @notice Cancels a proposal only if sender is the proposer, or proposer delegates dropped below proposal threshold
+     * @notice Cancels a proposal if sender is the proposer or proposalGuardian. Can be called by anyone if the proposer delegates dropped below proposal threshold.
      * @param proposalId The id of the proposal to cancel
      */
     function cancel(uint proposalId) external {
@@ -379,14 +379,14 @@ contract GovernorBravoDelegate is
 
         Proposal storage proposal = proposals[proposalId];
 
-        // Proposer can cancel
+        // Proposer or proposalGuardian can cancel
         if (msg.sender != proposal.proposer && msg.sender != proposalGuardian) {
             require(
                 (comp.getPriorVotes(proposal.proposer, block.number - 1) <
                     proposalThreshold),
                 "GovernorBravo::cancel: proposer above threshold"
             );
-            // Whitelisted proposers can't be canceled for falling below proposal threshold
+            // Only whitelist guardian can cancel proposals from whitelisted proposers with delegations below the proposal threshold
             if (isWhitelisted(proposal.proposer)) {
                 require(
                     msg.sender == whitelistGuardian,

--- a/contracts/GovernorBravoInterfaces.sol
+++ b/contracts/GovernorBravoInterfaces.sol
@@ -48,6 +48,9 @@ contract GovernorBravoEvents {
 
     /// @notice Emitted when the whitelistGuardian is set
     event WhitelistGuardianSet(address oldGuardian, address newGuardian);
+
+    /// @notice Emitted when the proposalGuardian is set
+    event ProposalGuardianSet(address oldProposalGuardian, address newProposalGuardian);
 }
 
 contract GovernorBravoDelegatorStorage {
@@ -176,6 +179,11 @@ contract GovernorBravoDelegateStorageV2 is GovernorBravoDelegateStorageV1 {
 
     /// @notice Address which manages whitelisted proposals and whitelist accounts
     address public whitelistGuardian;
+}
+
+contract GovernorBravoDelegateStorageV3 is GovernorBravoDelegateStorageV2 {
+    /// @notice Address which has the ability to cancel proposals
+    address public proposalGuardian;
 }
 
 interface TimelockInterface {

--- a/contracts/GovernorBravoInterfaces.sol
+++ b/contracts/GovernorBravoInterfaces.sol
@@ -182,11 +182,16 @@ contract GovernorBravoDelegateStorageV2 is GovernorBravoDelegateStorageV1 {
 }
 
 contract GovernorBravoDelegateStorageV3 is GovernorBravoDelegateStorageV2 {
-    /// @notice Address which has the ability to cancel proposals
-    address internal _proposalGuardian;
+    /// @notice The address and expiration of the proposal guardian.
+    struct ProposalGuardian {
+        // Address of the `ProposalGuardian`
+        address account;
+        // Timestamp at which the guardian loses the ability to cancel proposals
+        uint96 expiration;
+    }
 
-    /// @notice Timestamp at which the proposalGuardian stored in the `_proposalGuardian` variable is set to expire
-    uint96 internal _proposalGuardianExpiry;
+    /// @notice Account which has the ability to cancel proposals. This privilege expires at the given expiration timestamp.
+    ProposalGuardian public proposalGuardian;
 }
 
 interface TimelockInterface {

--- a/contracts/GovernorBravoInterfaces.sol
+++ b/contracts/GovernorBravoInterfaces.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 pragma solidity ^0.8.10;
 
-
 contract GovernorBravoEvents {
     /// @notice An event emitted when a new proposal is created
     event ProposalCreated(uint id, address proposer, address[] targets, uint[] values, string[] signatures, bytes[] calldatas, uint startBlock, uint endBlock, string description);
@@ -50,7 +49,11 @@ contract GovernorBravoEvents {
     event WhitelistGuardianSet(address oldGuardian, address newGuardian);
 
     /// @notice Emitted when the proposalGuardian is set
-    event ProposalGuardianSet(address oldProposalGuardian, address newProposalGuardian);
+    event ProposalGuardianSet(
+        address oldProposalGuardian, 
+        uint96 oldProposalGuardianExpiry, 
+        address newProposalGuardian, 
+        uint newProposalGuardianExpiry);
 }
 
 contract GovernorBravoDelegatorStorage {
@@ -64,7 +67,6 @@ contract GovernorBravoDelegatorStorage {
     address public implementation;
 }
 
-
 /**
  * @title Storage for Governor Bravo Delegate
  * @notice For future upgrades, do not change GovernorBravoDelegateStorageV1. Create a new
@@ -72,7 +74,6 @@ contract GovernorBravoDelegatorStorage {
  * GovernorBravoDelegateStorageVX.
  */
 contract GovernorBravoDelegateStorageV1 is GovernorBravoDelegatorStorage {
-
     /// @notice The delay before voting on a proposal may take place, once proposed, in blocks
     uint public votingDelay;
 
@@ -99,7 +100,6 @@ contract GovernorBravoDelegateStorageV1 is GovernorBravoDelegatorStorage {
 
     /// @notice The latest proposal for each proposer
     mapping (address => uint) public latestProposalIds;
-
 
     struct Proposal {
         /// @notice Unique id for looking up a proposal
@@ -183,7 +183,10 @@ contract GovernorBravoDelegateStorageV2 is GovernorBravoDelegateStorageV1 {
 
 contract GovernorBravoDelegateStorageV3 is GovernorBravoDelegateStorageV2 {
     /// @notice Address which has the ability to cancel proposals
-    address public proposalGuardian;
+    address internal _proposalGuardian;
+
+    /// @notice Timestamp at which the proposalGuardian stored in the `_proposalGuardian` variable is set to expire
+    uint96 internal _proposalGuardianExpiry;
 }
 
 interface TimelockInterface {

--- a/test/ForkTestSimulateUpgrade.ts
+++ b/test/ForkTestSimulateUpgrade.ts
@@ -109,6 +109,9 @@ describe("ForkTestSimulateUpgrade", function () {
     expect(await governorBravoDelegator.timelock()).to.equal(
       "0x6d903f6003cca6255D85CcA4D3B5E5146dC33925"
     );
+    expect(await governorBravoDelegator.whitelistGuardian()).to.equal(
+      "0xbbf3f1421D886E9b2c5D716B5192aC998af2012c"
+    );
   });
 
   it("Grant COMP proposal", async function () {
@@ -175,5 +178,36 @@ describe("ForkTestSimulateUpgrade", function () {
     )
       .to.emit(governorBravoDelegator, "VoteCast")
       .withArgs(signer.address, proposalId, 1, BigInt("1000"), "Great Idea!");
+  });
+
+  it("Set proposal guardian", async function () {
+    const { governorBravoDelegator, proposingSigner } = await loadFixture(
+      deployFixtures
+    );
+    const [signer] = await ethers.getSigners();
+    const setProposalGuardianSelector = ethers
+      .id("_setProposalGuardian(address)")
+      .substring(0, 10);
+    const setProposalGuardianData =
+      setProposalGuardianSelector +
+      ethers.AbiCoder.defaultAbiCoder()
+        .encode(["address"], [signer.address])
+        .slice(2);
+
+    expect(await governorBravoDelegator.proposalGuardian()).to.equal(
+      ethers.ZeroAddress
+    );
+
+    await proposeAndExecute(
+      governorBravoDelegator.connect(proposingSigner),
+      [await governorBravoDelegator.getAddress()],
+      [0],
+      [setProposalGuardianData],
+      "Set Proposal Guardian"
+    );
+
+    expect(await governorBravoDelegator.proposalGuardian()).to.equal(
+      signer.address
+    );
   });
 });

--- a/test/ForkTestSimulateUpgrade.ts
+++ b/test/ForkTestSimulateUpgrade.ts
@@ -187,24 +187,19 @@ describe("ForkTestSimulateUpgrade", function () {
     );
     const [signer] = await ethers.getSigners();
     const setProposalGuardianSelector = ethers
-      .id("_setProposalGuardian(address,uint96)")
+      .id("_setProposalGuardian((address,uint96))")
       .substring(0, 10);
+    const expirationTimestamp = (await time.latest()) + 6 * 30 * 24 * 60 * 60; // Expire in 6 months
     const setProposalGuardianData =
       setProposalGuardianSelector +
       ethers.AbiCoder.defaultAbiCoder()
-        .encode(
-          ["address", "uint96"],
-          [
-            signer.address,
-            (await time.latest()) +
-              6 * 30 * 24 * 60 * 60 /* Expire in 6 months */,
-          ]
-        )
+        .encode(["address", "uint96"], [signer.address, expirationTimestamp])
         .slice(2);
 
-    expect(await governorBravoDelegator.proposalGuardian()).to.equal(
-      ethers.ZeroAddress
-    );
+    expect(await governorBravoDelegator.proposalGuardian()).to.deep.equal([
+      ethers.ZeroAddress,
+      0,
+    ]);
 
     await proposeAndExecute(
       governorBravoDelegator.connect(proposingSigner),
@@ -214,8 +209,9 @@ describe("ForkTestSimulateUpgrade", function () {
       "Set Proposal Guardian"
     );
 
-    expect(await governorBravoDelegator.proposalGuardian()).to.equal(
-      signer.address
-    );
+    expect(await governorBravoDelegator.proposalGuardian()).to.deep.equal([
+      signer.address,
+      expirationTimestamp,
+    ]);
   });
 });

--- a/test/ForkTestSimulateUpgrade.ts
+++ b/test/ForkTestSimulateUpgrade.ts
@@ -30,7 +30,7 @@ describe("ForkTestSimulateUpgrade", function () {
       "0xc0Da02939E1441F497fd74F78cE7Decb17B66529"
     );
     const proposingSigner = await ethers.getSigner(
-      "0x2775b1c75658Be0F640272CCb8c72ac986009e38"
+      "0xF977814e90dA44bFA03b6295A0616a897441aceC"
     );
     await hardhat.network.provider.send("hardhat_setBalance", [
       proposingSigner.address,

--- a/test/ForkTestSimulateUpgrade.ts
+++ b/test/ForkTestSimulateUpgrade.ts
@@ -11,6 +11,7 @@ import {
   reset,
   impersonateAccount,
   loadFixture,
+  time,
 } from "@nomicfoundation/hardhat-network-helpers";
 
 describe("ForkTestSimulateUpgrade", function () {
@@ -186,12 +187,19 @@ describe("ForkTestSimulateUpgrade", function () {
     );
     const [signer] = await ethers.getSigners();
     const setProposalGuardianSelector = ethers
-      .id("_setProposalGuardian(address)")
+      .id("_setProposalGuardian(address,uint96)")
       .substring(0, 10);
     const setProposalGuardianData =
       setProposalGuardianSelector +
       ethers.AbiCoder.defaultAbiCoder()
-        .encode(["address"], [signer.address])
+        .encode(
+          ["address", "uint96"],
+          [
+            signer.address,
+            (await time.latest()) +
+              6 * 30 * 24 * 60 * 60 /* Expire in 6 months */,
+          ]
+        )
         .slice(2);
 
     expect(await governorBravoDelegator.proposalGuardian()).to.equal(

--- a/test/GovernorBravo.ts
+++ b/test/GovernorBravo.ts
@@ -692,7 +692,7 @@ describe("Governor Bravo", function () {
       ).to.be.revertedWith("GovernorBravo::cancel: proposer above threshold");
     });
 
-    it.only("Happy path: guardian can cancel", async function () {
+    it("Happy path: guardian can cancel", async function () {
       const { governorBravo, otherAccount } = await loadFixture(deployFixtures);
       const proposalId = await proposeAndPass(governorBravo);
 


### PR DESCRIPTION
Add a `proposalGuardian` to Governor Bravo. This guardian has the ability to cancel all proposals (except those that have been executed). The `proposalGuardian` can only be set by governance.